### PR TITLE
fix: add missing req_method arg for generate_short_url tool

### DIFF
--- a/tinyurl/pyproject.toml
+++ b/tinyurl/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tinyurl-mcp"
-version = "1.0.0"
+version = "1.0.1"
 description = "MCP Server for tinyurl.com"
 readme = "README.md"
 license = "Apache-2.0"

--- a/tinyurl/src/tinyurl_mcp/tools.py
+++ b/tinyurl/src/tinyurl_mcp/tools.py
@@ -31,7 +31,9 @@ async def generate_short_url(
 
     logger.info("Making an API request to generate a new short URL...")
     api_response = await make_api_request(
-        api_path="create", req_data=req_data.model_dump_json(exclude_none=True)
+        api_path="create",
+        req_method=RequestMethod.POST,
+        req_data=req_data.model_dump_json(exclude_none=True),
     )
 
     if api_response["code"] == 0:


### PR DESCRIPTION
## Overview

- add missing `req_method` arg for `generate_short_url` tool