### PR TITLE
fix: exclude listing of the current directory for tj-actions/changed-files action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           dir_names: true
           dir_names_max_depth: '1'
+          dir_names_exclude_current_dir: true
           files_ignore: |
             README.md
             .github/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
     needs: [detect-changed-dirs]
     if: needs.detect-changed-dirs.outputs.all_changed_dirs != '[]'
     strategy:
+      fail-fast: false
       matrix:
         dirs: ${{ fromJson(needs.detect-changed-dirs.outputs.all_changed_dirs) }}
     defaults:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,10 @@ jobs:
       - name: Get previous tag
         id: prev-tag
         run: |
-          echo "tag=$(git tag --sort=-creatordate | sed -n 2p)" >> $GITHUB_OUTPUT
+          prev_tag="$(git tag --sort=-creatordate | sed -n 2p)"
+          echo "prev_tag=${prev_tag}"
+
+          echo "tag=${prev_tag}" >> $GITHUB_OUTPUT
 
       - name: Get all mcp dirs
         if: steps.prev-tag.outputs.tag == ''
@@ -40,6 +43,7 @@ jobs:
         with:
           dir_names: true
           dir_names_max_depth: '1'
+          dir_names_exclude_current_dir: true
           files_ignore: |
             README.md
             .github/**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,7 @@ jobs:
     needs: [detect-changed-dirs]
     if: needs.detect-changed-dirs.outputs.all_changed_dirs != '[]'
     strategy:
+      fail-fast: false
       matrix:
         dirs: ${{ fromJson(needs.detect-changed-dirs.outputs.all_changed_dirs) }}
     defaults:


### PR DESCRIPTION
## Overview

- exclude listing of the current directory for tj-actions/changed-files action
- set `fail-fast` to false for handling matrix job failures

<img width="340" height="262" alt="Screenshot 2025-09-10 at 10 11 32 am" src="https://github.com/user-attachments/assets/cea3bd55-81fc-4dfb-ad51-ce5ec412bedb" />
